### PR TITLE
Random networks: Use temp dirs as data intermediaries

### DIFF
--- a/example_datasets_and_commands/microbiome_and_phenotype/input/example_commands.txt
+++ b/example_datasets_and_commands/microbiome_and_phenotype/input/example_commands.txt
@@ -22,11 +22,11 @@ Python version: 3.8.10
 		python ./analysis/calc_network_properties.py --pickle ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/network.pickle --bibc --bibc-groups node_types --bibc-calc-type rbc --node-map ./example_datasets_and_commands/microbiome_and_phenotype/input/type_map.csv --node-groups microbe pheno
 
 # 4. Create random networks and analyze
-	python ./random_networks/create_random_networks.py --template-network ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/network.pickle --networks-file ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/all_random_networks.pickle
+	python ./random_networks/create_random_networks.py --template-network ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/network.pickle --networks-file ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/all_random_networks.zip
 
-	python ./random_networks/compute_network_stats.py --networks-file ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/all_random_networks.pickle --bibc-groups node_types --bibc-calc-type rbc --stats-file ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/random_network_analysis.pickle --node-map ./example_datasets_and_commands/microbiome_and_phenotype/input/type_map.csv --node-groups microbe pheno
+	python ./random_networks/compute_network_stats.py --networks-file ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/all_random_networks.zip --bibc-groups node_types --bibc-calc-type rbc --stats-file ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/random_network_analysis.zip --node-map ./example_datasets_and_commands/microbiome_and_phenotype/input/type_map.csv --node-groups microbe pheno
 	
-	python ./random_networks/synthesize_network_stats.py --network-stats-file ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/random_network_analysis.pickle --synthesized-stats-file ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/random_networks_synthesized.csv
+	python ./random_networks/synthesize_network_stats.py --network-stats-file ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/random_network_analysis.zip --synthesized-stats-file ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/random_networks_synthesized.csv
 	
 # 5. Visualization
 	python ./visualization/dot_plots.py --pickle ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/network.pickle --node-props ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/node_properties.txt --network-file ./example_datasets_and_commands/microbiome_and_phenotype/output/network_output/network_output_comp.csv --propx BiBC --propy Node_degrees --top-num 10 --top-num-per-type 5

--- a/random_networks/compute_network_stats.py
+++ b/random_networks/compute_network_stats.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from community import community_louvain
 import csv
 from functools import partial
+import json
 from multiprocessing import Pool
 import networkx as nx
 import os
@@ -102,7 +103,9 @@ def restrictedBetweennessCentrality(network, nodes1, nodes2, normalize):
 	return rbcs
 
 def calculateNetworkStats(args, networksTempDirPath, statsTempDirPath, networkName):
-	network = nx.read_adjlist(networksTempDirPath / networkName)
+	with open(networksTempDirPath / networkName) as networkFile:
+		networkData = json.load(networkFile)
+	network = nx.readwrite.json_graph.adjacency_graph(networkData)
 
 	sortedSubgraphs = sorted([network.subgraph(component) for component in nx.connected_components(network)], key=len, reverse=True)
 

--- a/random_networks/create_random_networks.py
+++ b/random_networks/create_random_networks.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 from functools import partial
+import json
 from math import factorial
 from multiprocessing import Pool
 import networkx as nx
@@ -26,7 +27,9 @@ def generateNetwork(nodes, numEdges, tempDirPath, index, seed):
 				network.add_edge(node1, node2)
 				break
 
-	nx.write_adjlist(network, tempDirPath / str(index))
+	networkData = nx.readwrite.json_graph.adjacency_data(network)
+	with open(tempDirPath / str(index), "w") as networkFile:
+		json.dump(networkData, networkFile)
 
 def getArgs():
 	parser = argparse.ArgumentParser(description="Generate random networks", add_help=False)


### PR DESCRIPTION
Instead of keeping all data in memory and writing it to a pickle file at the end of random network generation or stat computation, each process writes its results to a new file in a temporary directory. Then, at the end of a script, this directory is zipped.