### PR TITLE
 In error message, differentiate between node groups not being in map and not being in giant component

### DIFF
--- a/random_networks/compute_network_stats.py
+++ b/random_networks/compute_network_stats.py
@@ -78,7 +78,7 @@ def nodesByType(args, network):
 		if nodeGroup not in allTypes:
 			raise Exception(f"Specified node group \"{nodeGroup}\" not in node map")
 		if nodeGroup not in nodeMap:
-			raise Exception(f"Specified node group \"{nodeGroup}\" not present in the largest component of a network. This is likely due to high sparcity in the generated networks.")
+			raise Exception(f"Specified node group \"{nodeGroup}\" not present in the largest component of a network. This is likely due to low density in the generated networks.")
 
 	return nodeMap[args.nodeGroups[0]], nodeMap[args.nodeGroups[1]]
 

--- a/random_networks/compute_network_stats.py
+++ b/random_networks/compute_network_stats.py
@@ -65,16 +65,20 @@ def largestClusters(network):
 # Returns two lists of nodes, one for each type.
 def nodesByType(args, network):
 	nodeMap = defaultdict(list)
+	allTypes = []
 	with open(args.nodeMap) as nodeMapFile:
 		nodeMapReader = csv.reader(nodeMapFile)
 		for row in nodeMapReader:
 			node, nodeType = row[0], row[1]
+			allTypes.append(nodeType)
 			if node in network.nodes:
 				nodeMap[nodeType].append(node)
 
 	for nodeGroup in args.nodeGroups:
-		if nodeGroup not in nodeMap:
+		if nodeGroup not in allTypes:
 			raise Exception(f"Specified node group \"{nodeGroup}\" not in node map")
+		if nodeGroup not in nodeMap:
+			raise Exception(f"Specified node group \"{nodeGroup}\" not present in the largest component of a network. This is likely due to high sparcity in the generated networks.")
 
 	return nodeMap[args.nodeGroups[0]], nodeMap[args.nodeGroups[1]]
 


### PR DESCRIPTION
Sometimes, the giant component of a network may not contain both specified node types. Currently, this results in an error saying the type is not in the type map, which is false. This change specifically checks for this scenario and gives a corresponding error message.