### PR TITLE
Add argument to parallelized scripts to control number of cores used

### DIFF
--- a/random_networks/compute_network_stats.py
+++ b/random_networks/compute_network_stats.py
@@ -25,6 +25,7 @@ def getArgs():
 	requiredArgGroup.add_argument("--stats-file", type=str, dest="statsFile", required=True, help="ZIP to output the network stats to")
 	optionalArgGroup.add_argument("--node-map", "-m", dest="nodeMap", help="CSV file mapping nodes to their types. Required if node_types is specified for --bibc-groups.")
 	optionalArgGroup.add_argument("--node-groups", "-g", metavar="GROUP", nargs=2, dest="nodeGroups", help="Two types of nodes to use for BiBC grouping. Required if node_types is specified for --bibc-groups.")
+	optionalArgGroup.add_argument("--cores", type=int, help="Number of cores to use for computation. If not provided, all available cores will be used.")
 	optionalArgGroup.add_argument("-h", "--help", action="help", help="Show this help message and exit")
 	args = parser.parse_args()
 
@@ -141,7 +142,7 @@ if __name__ == "__main__":
 	statsTempDir = tempfile.TemporaryDirectory()
 	statsTempDirPath = Path(statsTempDir.name)
 
-	with Pool() as pool:
+	with Pool(args.cores) as pool:
 		pool.map(partial(calculateNetworkStats, args, networksTempDirPath, statsTempDirPath), os.listdir(networksTempDirPath))
 
 	networksTempDir.cleanup()

--- a/random_networks/create_random_networks.py
+++ b/random_networks/create_random_networks.py
@@ -44,6 +44,7 @@ def getArgs():
 	requiredArgGroup.add_argument("--networks-file", type=str, dest="networksFile", required=True, help="ZIP file to output networks to")
 
 	optionalArgGroup.add_argument("--num-networks", "-n", type=int, dest="numNetworks", default=10000, help="Number of networks to generate")
+	optionalArgGroup.add_argument("--cores", type=int, help="Number of cores to use for computation. If not provided, all available cores will be used.")
 	optionalArgGroup.add_argument("-h", "--help", action="help", help="Show this help message and exit")
 
 	args = parser.parse_args()
@@ -94,7 +95,7 @@ if __name__ == "__main__":
 
 	tempDir = tempfile.TemporaryDirectory()
 	tempDirPath = Path(tempDir.name)
-	with Pool() as pool:
+	with Pool(args.cores) as pool:
 		pool.starmap(partial(generateNetwork, nodes, numEdges, tempDirPath), enumerate(seeds))
 
 	args.networksFile.parent.mkdir(parents=True, exist_ok=True)

--- a/reconstruction/reconstruction/NetworkReconstructorAggregate.py
+++ b/reconstruction/reconstruction/NetworkReconstructorAggregate.py
@@ -312,7 +312,7 @@ def combineAndFilterFoldChanges(config, foldChanges, foldChangeSigns):
 
 	return combinedSigns, filterTable
 
-def calculateCorrelations(config, filteredData):
+def calculateCorrelations(config, filteredData, cores=None):
 	metatreatments = config["metatreatments"]
 	if metatreatments is None:
 		metatreatments = {}
@@ -406,7 +406,7 @@ def calculateCorrelations(config, filteredData):
 			endArgs = []
 
 		worker = methodWorker(**methodKwargs, treatmentDataParams=treatmentDataParams, correlationsAndPValuesParams=correlationsAndPValuesParams)
-		with Pool() as p:
+		with Pool(cores) as p:
 			p.map(worker, itertools.combinations(range(treatmentData.sizes["measurable"]), 2))
 
 		treatmentDataSharedMemory.close()
@@ -607,7 +607,7 @@ def filterOnExpectedEdges(config, foldChangeSigns, correlationSigns):
 	return pucCompliant, foldChangeSignProducts
 
 class NetworkReconstructorAggregate(NetworkReconstructor):
-	def reconstructNetwork(self, config, data, **kwargs):
+	def reconstructNetwork(self, config, data, cores=None, **kwargs):
 		skip = False
 
 		def computeDifferences(allData):
@@ -633,7 +633,7 @@ class NetworkReconstructorAggregate(NetworkReconstructor):
 				skip = True
 				return
 
-			allData["correlationCoefficients"], allData["correlationPValues"] = calculateCorrelations(config, allData["filteredData"])
+			allData["correlationCoefficients"], allData["correlationPValues"] = calculateCorrelations(config, allData["filteredData"], cores)
 
 			allData["correlationSigns"] = numpy.sign(allData["correlationCoefficients"])
 			allData["combinedCorrelationSigns"], allData["correlationFilter"], allData["metatreatmentsPassingCorrelationFilter"] = combineAndFilterCorrelations(config, allData["correlationCoefficients"], allData["correlationSigns"])

--- a/reconstruction/run.py
+++ b/reconstruction/run.py
@@ -18,6 +18,7 @@ def getArgs():
 	requiredArgGroup.add_argument("--out-file", type=str, dest="outFile", required=True, help="Writes all generated data to a ZIP file with the specified path")
 	optionalArgGroup.add_argument("--start", nargs=2, type=str, metavar=("startStage", "startData"), help="Start network generation from a particular stage")
 	optionalArgGroup.add_argument("--stop", nargs=1, type=str, metavar="stopStage", help="Stop network generation at a particular stage")
+	optionalArgGroup.add_argument("--cores", type=int, help="Number of cores to use for computation. If not provided, all available cores will be used.")
 	optionalArgGroup.add_argument("--singlecell", "-s", action="store_true", default=False, help="Work with single-cell rather than aggregate data")
 	optionalArgGroup.add_argument("-h", "--help", action="help", help="Show this help message and exit")
 	args = parser.parse_args()
@@ -64,5 +65,5 @@ if __name__ == "__main__":
 		network_reconstructor = NetworkReconstructorSingleCell()
 	else:
 		network_reconstructor = NetworkReconstructorAggregate()
-	network_reconstructor.reconstructNetwork(config, data, start=args.start, stopStage=args.stop, dataOutFilePath=args.outFile)
+	network_reconstructor.reconstructNetwork(config, data, start=args.start, stopStage=args.stop, dataOutFilePath=args.outFile, cores=args.cores)
 


### PR DESCRIPTION
New argument `--cores` added to the following scripts:

- `reconstruction/run.py`
- `random_networks/create_random_networks.py`
- `random_networks/compute_network_stats.py`