### PR TITLE
Refactor subsample creation and implement nested subsampling

### DIFF
--- a/reconstruction/create_subsamples.py
+++ b/reconstruction/create_subsamples.py
@@ -18,7 +18,7 @@ def getArgs():
 	requiredArgGroup.add_argument("-n", "--nsubsamples", type=int, required=True, help="Number of subsamples to generate.")
 	optionalArgGroup.add_argument("-s", "--singlecell", action="store_true", default=False, help="Create subsamples for single-cell data instead of aggregate data. By default, this will subsample cells rather than organisms. To override this behavior, use the -o/--organism option to subsample organisms or the -b/--both-organisms-and-cells option to subsample both.")
 	optionalArgGroup.add_argument("-o", "--organism", action="store_true", default=False, help="Subsample over organisms, even for single-cell data (this is the default behavior for aggregate data)")
-	optionalArgGroup.add_argument("-b", "--both-organisms-and-cells", dest="bothOrganismsAndCells", nargs=2, metavar=("ORGANISM_NSUBSAMPLES", "ORGANISM_PROPORTION"), help="Subsample over organisms, then over cells (only applicable to single-cell, -s). The additional arguments are the number of times to sample the organisms and the proportion of organisms in each treatment to use for each subsample. For each sample of organisms, the cells in each organism will be sampled within their cell type NSUBSAMPLES (-n/--nsubsamples) times with proportion PROPORTION (-p/--proportion). This will produce a total of ORGANISM_NSUBSAMPLES * NSUBSAMPLES subsamples. Proportion must satisfy 0 < p < 1.")
+	optionalArgGroup.add_argument("-b", "--both-organisms-and-cells", dest="bothOrganismsAndCells", nargs=1, metavar="ORGANISM_PROPORTION", help="Subsample over organisms and cells (only applicable to single-cell, -s). The additional argument is the proportion of organisms in each treatment to use for each subsample and must satisfy 0 < p < 1.")
 	optionalArgGroup.add_argument("-h", "--help", action="help", help="Show this help message and exit")
 	args = parser.parse_args()
 
@@ -43,8 +43,7 @@ def getArgs():
 			raise Exception("Can only use -b/--both-organisms-and-single-cells with single-cell data (-s/--singlecell).")
 
 	if bothOrganismsAndCells:
-		args.organismNSubsamples = int(args.bothOrganismsAndCells[0])
-		args.organismProportion = float(args.bothOrganismsAndCells[1])
+		args.organismProportion = float(args.bothOrganismsAndCells[0])
 		if args.organismProportion <= 0 or args.organismProportion >= 1:
 			raise Exception("Proportion of organisms out of bounds. Must satisfy 0 < p < 1.")
 
@@ -89,26 +88,22 @@ if __name__ == "__main__":
 			organismCellMap[organism].append(index)
 
 		def subsampleCells(organisms):
-			subsamples = []
-			for i in range(args.nsubsamples):
-				subsample = []
-				for organism in organisms:
-					organismCellIndices = set(organismCellMap[organism])
-					for cellType in cellTypeMap:
-						cellTypeCellIndices = set(cellTypeMap[cellType])
-						matchingCellIndices = organismCellIndices.intersection(cellTypeCellIndices)
-						subsetSubsampleSize = round(args.proportion * len(matchingCellIndices))
-						subsetSubsample = random.sample(matchingCellIndices, subsetSubsampleSize)
-						subsample.extend(subsetSubsample)
-				subsample.sort()
-				subsamples.append(subsample)
-			return subsamples
+			subsample = []
+			for organism in organisms:
+				organismCellIndices = set(organismCellMap[organism])
+				for cellType in cellTypeMap:
+					cellTypeCellIndices = set(cellTypeMap[cellType])
+					matchingCellIndices = organismCellIndices.intersection(cellTypeCellIndices)
+					subsetSubsampleSize = round(args.proportion * len(matchingCellIndices))
+					subsetSubsample = random.sample(matchingCellIndices, subsetSubsampleSize)
+					subsample.extend(subsetSubsample)
+			subsample.sort()
+			return subsample
 
 		if args.organism or args.bothOrganismsAndCells:
 			# Take a sample of the organisms from each treatment
-			organismNSubsamples = args.nsubsamples if args.organism else args.organismNSubsamples
 			organismProportion = args.proportion if args.organism else args.organismProportion
-			for i in range(organismNSubsamples):
+			for i in range(args.nsubsamples):
 				organismSubsample = []
 				for experimentOrganisms in experimentMap.values():
 					for treatmentOrganisms in treatmentMap.values():
@@ -122,11 +117,12 @@ if __name__ == "__main__":
 					subsamples.append(subsample)
 				elif args.bothOrganismsAndCells:
 					# Now that we have a sample of the organisms, take a sample of each selected organism's cells within each cell type
-					subsamples.extend(subsampleCells(organismSubsample))
+					subsamples.append(subsampleCells(organismSubsample))
 				else:
 					raise Exception("Argument state invalid.")
 		else:
-			subsamples.extend(subsampleCells(organismCellMap.keys()))
+			for i in range(args.nsubsamples):
+				subsamples.append(subsampleCells(organismCellMap.keys()))
 	else:
 		data = dataset.get_table("originalData")
 

--- a/reconstruction/create_subsamples.py
+++ b/reconstruction/create_subsamples.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
 					treatmentSubsample = random.sample(treatmentOrganisms, treatmentSubsampleSize)
 					organismSubsample.extend(treatmentSubsample)
 				if args.organism:
-					subsample = list(itertools.chain(organismCellMap[organism] for organism in organismSubsample))
+					subsample = list(itertools.chain(*[organismCellMap[organism] for organism in organismSubsample]))
 					subsamples.append(subsample)
 				elif args.bothOrganismsAndCells:
 					# Now that we have a sample of the organisms, take a sample of each selected organism's cells within each cell type

--- a/reconstruction/create_subsamples.py
+++ b/reconstruction/create_subsamples.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import itertools
 import json
 import numpy
 from pathlib import Path
@@ -15,8 +16,9 @@ def getArgs():
 	requiredArgGroup.add_argument("--subsample-file", type=str, dest="subsampleFile", required=True, help="File to write the subsample descriptions to")
 	requiredArgGroup.add_argument("-p", "--proportion", type=float, required=True, help="Proportion of samples to put in each subsample. Must satisfy 0 < p < 1.")
 	requiredArgGroup.add_argument("-n", "--nsubsamples", type=int, required=True, help="Number of subsamples to generate.")
-	optionalArgGroup.add_argument("-s", "--singlecell", action="store_true", default=False, help="Create subsamples for single-cell data instead of aggregate data")
+	optionalArgGroup.add_argument("-s", "--singlecell", action="store_true", default=False, help="Create subsamples for single-cell data instead of aggregate data. By default, this will subsample cells rather than organisms. To override this behavior, use the -o/--organism option to subsample organisms or the -b/--both-organisms-and-cells option to subsample both.")
 	optionalArgGroup.add_argument("-o", "--organism", action="store_true", default=False, help="Subsample over organisms, even for single-cell data (this is the default behavior for aggregate data)")
+	optionalArgGroup.add_argument("-b", "--both-organisms-and-cells", dest="bothOrganismsAndCells", nargs=2, metavar=("ORGANISM_NSUBSAMPLES", "ORGANISM_PROPORTION"), help="Subsample over organisms, then over cells (only applicable to single-cell, -s). The additional arguments are the number of times to sample the organisms and the proportion of organisms in each treatment to use for each subsample. For each sample of organisms, the cells in each organism will be sampled within their cell type NSUBSAMPLES (-n/--nsubsamples) times with proportion PROPORTION (-p/--proportion). This will produce a total of ORGANISM_NSUBSAMPLES * NSUBSAMPLES subsamples. Proportion must satisfy 0 < p < 1.")
 	optionalArgGroup.add_argument("-h", "--help", action="help", help="Show this help message and exit")
 	args = parser.parse_args()
 
@@ -29,6 +31,25 @@ def getArgs():
 	if args.proportion <= 0 or args.proportion >= 1:
 		raise Exception("Proportion of samples out of bounds. Must satisfy 0 < p < 1.")
 
+	bothOrganismsAndCells = args.bothOrganismsAndCells is not None
+
+	if args.singlecell:
+		if args.organism and bothOrganismsAndCells:
+			raise Exception("Cannot use the -o/--organism and -b/--both-organisms-and-cells options simultaneously.")
+	else:
+		if args.organism:
+			raise Exception("Can only use -o/--organism with single-cell data (-s/--singlecell)")
+		if bothOrganismsAndCells:
+			raise Exception("Can only use -b/--both-organisms-and-single-cells with single-cell data (-s/--singlecell).")
+
+	if bothOrganismsAndCells:
+		args.organismNSubsamples = int(args.bothOrganismsAndCells[0])
+		args.organismProportion = float(args.bothOrganismsAndCells[1])
+		if args.organismProportion <= 0 or args.organismProportion >= 1:
+			raise Exception("Proportion of organisms out of bounds. Must satisfy 0 < p < 1.")
+
+	args.bothOrganismsAndCells = bothOrganismsAndCells
+
 	return args
 
 if __name__ == "__main__":
@@ -40,31 +61,60 @@ if __name__ == "__main__":
 	subsamples = []
 	if args.singlecell:
 		data = dataset.get_table("cellData")
-		if args.organism:
-			organisms = numpy.array(list(set(data["organism"].data)))
-			nAllSamples = len(organisms)
-			nSamples = round(args.proportion * nAllSamples)
+
+		# Construct maps from dataset coordinates
+		organismCellMap = {} # organism -> list of indices of cells belonging to the organism
+		treatmentMap = {} # treatment -> list of organisms in treatment group
+		cellTypeMap = {} # cell type -> list of indices of cells of that type
+		for index, cellData in enumerate(data.cell):
+			organism = cellData.organism.item()
+			if organism not in organismCellMap:
+				organismCellMap[organism] = []
+				treatment = cellData.treatment.item()
+				if treatment not in treatmentMap:
+					treatmentMap[treatment] = []
+				treatmentMap[treatment].append(organism)
+			cellType = cellData.cellType.item()
+			if cellType not in cellTypeMap:
+				cellTypeMap[cellType] = []
+			cellTypeMap[cellType].append(index)
+			organismCellMap[organism].append(index)
+
+		def subsampleCells(organisms):
+			subsamples = []
 			for i in range(args.nsubsamples):
-				organismSubsample = random.sample(range(nAllSamples), nSamples)
-				cellSubsample = []
-				for organismIndex in organismSubsample:
-					organism = organisms[organismIndex]
-					organismCellIndices = numpy.argwhere((data.organism == organism).data).flatten().tolist()
-					cellSubsample.extend(organismCellIndices)
-				cellSubsample.sort()
-				subsamples.append(cellSubsample)
+				subsample = []
+				for organism in organisms:
+					organismCellIndices = set(organismCellMap[organism])
+					for cellType in cellTypeMap:
+						cellTypeCellIndices = set(cellTypeMap[cellType])
+						matchingCellIndices = organismCellIndices.intersection(cellTypeCellIndices)
+						subsetSubsampleSize = round(args.proportion * len(matchingCellIndices))
+						subsetSubsample = random.sample(matchingCellIndices, subsetSubsampleSize)
+						subsample.extend(subsetSubsample)
+				subsamples.append(subsample)
+			return subsamples
+
+		if args.organism or args.bothOrganismsAndCells:
+			# Take a sample of the organisms from each treatment
+			organismNSubsamples = args.nsubsamples if args.organism else args.organismNSubsamples
+			organismProportion = args.proportion if args.organism else args.organismProportion
+			for i in range(organismNSubsamples):
+				organismSubsample = []
+				for treatmentOrganisms in treatmentMap.values():
+					treatmentSubsampleSize = round(organismProportion * len(treatmentOrganisms))
+					treatmentSubsample = random.sample(treatmentOrganisms, treatmentSubsampleSize)
+					organismSubsample.extend(treatmentSubsample)
+				if args.organism:
+					subsample = list(itertools.chain(organismCellMap[organism] for organism in organismSubsample))
+					subsamples.append(subsample)
+				elif args.bothOrganismsAndCells:
+					# Now that we have a sample of the organisms, take a sample of each selected organism's cells within each cell type
+					subsamples.extend(subsampleCells(organismSubsample))
+				else:
+					raise Exception("Argument state invalid.")
 		else:
-			for i in range(args.nsubsamples):
-				coordSubsample = []
-				def subsamplePopulation(data):
-					nAllSamples = data.sizes["cell"]
-					nSamples = round(args.proportion * nAllSamples)
-					populationCoordSubsample = random.sample(list(data.coords["cell"].data), nSamples)
-					coordSubsample.extend(populationCoordSubsample)
-					return data
-				data.groupby("organism").map(lambda individualData: individualData.groupby("cellType").map(subsamplePopulation))
-				indexSubsample = list(numpy.transpose(numpy.argwhere(numpy.isin(data.cell, coordSubsample))).astype(object)[0])
-				subsamples.append(indexSubsample)
+			subsamples.extend(subsampleCells(organismCellMap.keys()))
 	else:
 		data = dataset.get_table("originalData")
 		nAllSamples = data.sizes["organism"]

--- a/reconstruction/create_subsamples.py
+++ b/reconstruction/create_subsamples.py
@@ -117,11 +117,20 @@ if __name__ == "__main__":
 			subsamples.extend(subsampleCells(organismCellMap.keys()))
 	else:
 		data = dataset.get_table("originalData")
-		nAllSamples = data.sizes["organism"]
-		nSamples = round(args.proportion * nAllSamples)
+
+		treatmentMap = {} # treatment -> list of indices of organisms in treatment group
+		for index, organism in enumerate(data.organism):
+			treatment = organism.treatment.item()
+			if treatment not in treatmentMap:
+				treatmentMap[treatment] = []
+			treatmentMap[treatment].append(index)
+
 		for i in range(args.nsubsamples):
-			subsample = random.sample(range(nAllSamples), nSamples)
-			subsample.sort()
+			subsample = []
+			for treatmentOrganismIndices in treatmentMap.values():
+				treatmentSubsampleSize = round(args.proportion * len(treatmentOrganismIndices))
+				treatmentSubsample = random.sample(treatmentOrganismIndices, treatmentSubsampleSize)
+				subsample.extend(treatmentSubsample)
 			subsamples.append(subsample)
 
 	subsampleFile = open(args.subsampleFile, "w")

--- a/reconstruction/create_subsamples.py
+++ b/reconstruction/create_subsamples.py
@@ -92,6 +92,7 @@ if __name__ == "__main__":
 						subsetSubsampleSize = round(args.proportion * len(matchingCellIndices))
 						subsetSubsample = random.sample(matchingCellIndices, subsetSubsampleSize)
 						subsample.extend(subsetSubsample)
+				subsample.sort()
 				subsamples.append(subsample)
 			return subsamples
 
@@ -107,6 +108,7 @@ if __name__ == "__main__":
 					organismSubsample.extend(treatmentSubsample)
 				if args.organism:
 					subsample = list(itertools.chain(*[organismCellMap[organism] for organism in organismSubsample]))
+					subsample.sort()
 					subsamples.append(subsample)
 				elif args.bothOrganismsAndCells:
 					# Now that we have a sample of the organisms, take a sample of each selected organism's cells within each cell type
@@ -131,6 +133,7 @@ if __name__ == "__main__":
 				treatmentSubsampleSize = round(args.proportion * len(treatmentOrganismIndices))
 				treatmentSubsample = random.sample(treatmentOrganismIndices, treatmentSubsampleSize)
 				subsample.extend(treatmentSubsample)
+			subsample.sort()
 			subsamples.append(subsample)
 
 	subsampleFile = open(args.subsampleFile, "w")


### PR DESCRIPTION
Nested subsampling creates a subsample by sampling both the organisms in each treatment and the cells in each cell type in the selected organisms.

For aggregate data, the only available subsampling mode is over organisms. For single-cell data, the mode is specified in the following way:
- Default (no flags): Within each combination of organism and cell type, take samples of cells. Number of samples given to `-n` argument, proportion of cells to include given to `-p` argument.
- `-o`/`--organism`: Within each treatment, take samples of the organisms, but include all cells from each selected organism. Number of samples given to `-n` argument, proportion of organisms in each treatment to include given to `-p` argument.
- `-b`/`--both-organisms-and-cells` (NEW): For each subsample, take a sample of the organisms. Then, for each combination of selected organism and cell type, take a sample of cells. The final subsample is the collection of all cells selected in this manner. When using this option, the argument given to `-b` is the proportion of organisms to take, and the argument given to `-p` is the proportion of cells to take from each cell type within each organism.