### PR TITLE
Only show outliers once in abundance plots

### DIFF
--- a/visualization/plot_abundance.py
+++ b/visualization/plot_abundance.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
         for k,v in colordict.items():
             print(k,v)
 
-        ax = sns.boxplot(data=concat_df, x=grouping, y=nodename, hue=group_by, palette = colordict)
+        ax = sns.boxplot(data=concat_df, x=grouping, y=nodename, hue=group_by, palette = colordict, fliersize=0)
         handles, labels = ax.get_legend_handles_labels()
         # ax.legend(handles=handles,
         #     labels=treatments,


### PR DESCRIPTION
Currently, outliers are shown twice: once from the scatterplot and once from the box plot. This change makes it so that only the outliers from the scatterplot are shown.