### PR TITLE
Upgrade Pillow from 9.0.0 to 9.2.0 due to vulnerabilities in older versions of Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ numpy==1.22.0
 packaging==21.3
 pandas==1.3.5
 patsy==0.5.2
-Pillow==9.0.0
+Pillow==9.2.0
 pyparsing==3.0.6
 python-dateutil==2.8.2
 python-louvain==0.16


### PR DESCRIPTION
See:
- GHSA-8vj2-vxx3-667w
- GHSA-9j59-75qj-795w
- GHSA-m2vv-5vj5-2hm7