### PR TITLE
Update requirements to resolve vulnerabilities in older versions of some packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,11 @@ infomap==2.6.1
 kiwisolver==1.3.2
 matplotlib==3.5.1
 networkx==2.7.1
-numpy==1.22.0
+numpy==1.22.2
 packaging==21.3
 pandas==1.3.5
 patsy==0.5.2
-Pillow==9.2.0
+Pillow==9.3.0
 pyparsing==3.0.6
 python-dateutil==2.8.2
 python-louvain==0.16


### PR DESCRIPTION
Pillow: 9.2.0 -> 9.3.0
NumPy: 1.22.0 -> 1.22.2