### PR TITLE
Add option to filter on correlation coefficients

### DIFF
--- a/reconstruction/util/configs/Aggregate.py
+++ b/reconstruction/util/configs/Aggregate.py
@@ -57,6 +57,7 @@ aggregateConfigSpec = Config([
 		MultiTypeConfigItem("combined", [Number, dict], default=0.05),
 		MultiTypeConfigItem("corrected", [Number, dict], default=0.1)
 	]), default=UseSubDefaults()),
+	MultiTypeConfigItem("correlationCoefficientThresholds", [Number, dict], default=None),
 	TypedConfigItem("correlationFilterMethod", str, default="allsamesign"),
 	TypedConfigItem("correlationFilterPercentAgreementThreshold", Number, default=0.75),
 	TypedConfigItem("metatreatments", dict, default=None),

--- a/reconstruction/util/configs/SingleCell.py
+++ b/reconstruction/util/configs/SingleCell.py
@@ -53,6 +53,7 @@ singleCellConfigSpec = Config([
 		MultiTypeConfigItem("combined", [Number, dict], default=0.05),
 		MultiTypeConfigItem("corrected", [Number, dict], default=0.1)
 	]), default=UseSubDefaults()),
+	MultiTypeConfigItem("correlationCoefficientThresholds", [Number, dict], default=None),
 	TypedConfigItem("correlationFilterMethod", str, default="allsamesign"),
 	TypedConfigItem("correlationFilterPercentAgreementThreshold", Number, default=0.75),
 	TypedConfigItem("correctCorrelationPValuesAfterConsistencyFiltering", bool, default=False),


### PR DESCRIPTION
Using the new `correlationCoefficientThresholds` config option enables this filter. It can be set to either a single value for all combinations of cell type or different values for each combination, similar to `correlationPValueThresholds`.