### PR TITLE
Shorten shared memory names to avoid error on macOS

### DIFF
--- a/reconstruction/reconstruction/NetworkReconstructorAggregate.py
+++ b/reconstruction/reconstruction/NetworkReconstructorAggregate.py
@@ -362,7 +362,10 @@ def calculateCorrelations(config, filteredData, cores=None):
 	filteredData = filteredData.assign_coords(coords={"metatreatment": ("organism", metatreatmentCoords)})
 
 	# Used to identify the current run's shared memory
-	runnerId = str(time.time())
+	# NB: macOS limits shared memory names to 31 characters, so we need to round to
+	#     the nearest millisecond rather than using the full timestamp
+	#     https://stackoverflow.com/questions/38049068/osx-shm-open-returns-enametoolong
+	runnerId = str(int(time.time() * 1000))
 
 	def prepareSpearman(treatmentData):
 		spearmanKwargs = {}

--- a/reconstruction/reconstruction/NetworkReconstructorSingleCell.py
+++ b/reconstruction/reconstruction/NetworkReconstructorSingleCell.py
@@ -225,7 +225,10 @@ def calculateCorrelations(config, filteredData, cores=None):
 	filteredData = filteredData.assign_coords(coords={"metatreatment": ("organism", metatreatmentCoords)})
 
 	# Used to identify the current run's shared memory
-	runnerId = str(time.time())
+	# NB: macOS limits shared memory names to 31 characters, so we need to round to
+	#     the nearest millisecond rather than using the full timestamp
+	#     https://stackoverflow.com/questions/38049068/osx-shm-open-returns-enametoolong
+	runnerId = str(int(time.time() * 1000))
 
 	def prepareSpearman(treatmentData):
 		spearmanKwargs = {}


### PR DESCRIPTION
macOS shared memory names are limited to 31 characters, and using the full timestamp could sometimes push the name of the shared memory over that limit. To resolve this, this commit changes shared memory names to use the time as an integer rounded to the nearest millisecond rather than the full timestamp.